### PR TITLE
Set pinocchio version to prevent link error

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - urdfdom
     - assimp
     - octomap
-    - hpp-fcl ={{ major }}
+    - hpp-fcl
     - hpp-util ={{ major }}
     - hpp-statistics ={{ major }}
     - pinocchio ==2.5.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set name = "hpp-manipulation-corba" %}
+{% set major = "4.10" %}
 {% set version = "4.10.1" %}
 
 package:
@@ -29,17 +30,17 @@ requirements:
     - urdfdom
     - assimp
     - octomap
-    - hpp-fcl
-    - hpp-util
-    - hpp-statistics
+    - hpp-fcl ={{ major }}
+    - hpp-util ={{ major }}
+    - hpp-statistics ={{ major }}
     - pinocchio ==2.5.4
-    - hpp-pinocchio
-    - hpp-constraints
-    - hpp-core
-    - hpp-manipulation
-    - hpp-manipulation-urdf
-    - hpp-template-corba
-    - hpp-corbaserver
+    - hpp-pinocchio ={{ major }}
+    - hpp-constraints ={{ major }}
+    - hpp-core ={{ major }}
+    - hpp-manipulation ={{ major }}
+    - hpp-manipulation-urdf ={{ major }}
+    - hpp-template-corba ={{ major }}
+    - hpp-corbaserver ={{ major }}
     - omniorb
     - omniorbpy
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - hpp-fcl
     - hpp-util
     - hpp-statistics
+    - pinocchio==2.5.4
     - hpp-pinocchio
     - hpp-constraints
     - hpp-core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a5c9b36251b15868f20c680136c2383186b26a5aa60a1a310e23a0a34978bde3
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage(name|lower, max_pin='x.x') }}
@@ -32,7 +32,7 @@ requirements:
     - hpp-fcl
     - hpp-util
     - hpp-statistics
-    - pinocchio==2.5.4
+    - pinocchio ==2.5.4
     - hpp-pinocchio
     - hpp-constraints
     - hpp-core


### PR DESCRIPTION
This PR is a simple fix to prevent the following error when launching `hppcorbasrever` : 
`hppcorbaserver: error while loading shared libraries: libpinocchio.so.2.5.4: cannot open shared object file: No such file or directory`

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
